### PR TITLE
feat: add tags property to PacerPlan that propagates to its tasks

### DIFF
--- a/src/PacerPlan.helper.ts
+++ b/src/PacerPlan.helper.ts
@@ -76,7 +76,8 @@ export function generateTasksForPacerPlan(plan: PacerPlan, dateProvider: IDatePr
             quantityType: plan.quantityType,
             quantities,
             scheduledDate: currentDate,
-            completed: false
+            completed: false,
+            tags: plan.tags,
         }));
 
         currentPoint += currentTaskQuantityToAssign;

--- a/src/PacerPlan.ts
+++ b/src/PacerPlan.ts
@@ -8,11 +8,12 @@ export class PacerPlan {
     startDate: Date;
     endDate: Date;
     actionDays: Days;
+    quantityType: string;
     startNumber: number;
     endNumber: number;
+    tags: string[];
 
     tasks: Task[];
-    quantityType: string;
 
     constructor(
         {
@@ -24,7 +25,8 @@ export class PacerPlan {
             startNumber,
             endNumber,
             tasks,
-            quantityType
+            quantityType,
+            tags,
         }: {
             title?: string,
             summary?: string,
@@ -34,7 +36,8 @@ export class PacerPlan {
             startNumber?: number,
             endNumber?: number,
             tasks?: Task[],
-            quantityType?: string
+            quantityType?: string,
+            tags?: string[],
         } = {}) {
         this._title = sanitizeForFileName(title || "");
         this.summary = summary || "";
@@ -45,6 +48,7 @@ export class PacerPlan {
         this.endNumber = endNumber || 0;
         this.quantityType = quantityType || "";
         this.tasks = tasks || [];
+        this.tags = tags || [];
     }
 
     set title(value: string) {
@@ -52,7 +56,7 @@ export class PacerPlan {
     }
 
     get title(): string {
-        return this._title; 
+        return this._title;
     }
 
     get totalQuantity(): number {
@@ -70,8 +74,19 @@ actionDays: ${daysToShortString(this.actionDays)}
 quantityType: ${this.quantityType}
 startNumber: ${this.startNumber}
 endNumber: ${this.endNumber}
+tags:${this.getTagsString()}
 ---
 ${tasksString}
 `;
+    }
+
+    private getTagsString(): string {
+        let tagsString = this.tags.map(tag => `  - ${tag}`).join("\n");
+
+        if (this.tags.length > 0) {
+            tagsString = "\n" + tagsString;
+        }
+
+        return tagsString;
     }
 }

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -8,6 +8,7 @@ export class Task {
     completed: boolean;
     quantities: number[];
     additionalProperties: string;
+    tags: string[];
 
     constructor({
         description,
@@ -15,6 +16,7 @@ export class Task {
         quantities,
         scheduledDate,
         completed,
+        tags,
         additionalProperties
     }: {
         description: string;
@@ -22,6 +24,7 @@ export class Task {
         quantities: number[];
         scheduledDate: Date;
         completed: boolean;
+        tags?: string[];
         additionalProperties?: string;
     }) {
         this.description = description;
@@ -29,6 +32,7 @@ export class Task {
         this.quantities = quantities;
         this.scheduledDate = scheduledDate;
         this.completed = completed;
+        this.tags = tags ?? [];
         this.additionalProperties = additionalProperties ?? "";
     }
 
@@ -49,6 +53,8 @@ export class Task {
         const totalQuantity = this.quantities.length;
         const label = pluralize(this.quantityType, totalQuantity, false).toLowerCase();
 
-        return `${prefix} ${this.description} (${label} ${rangeString}) ⏳ ${this.scheduledDate.toISOString().slice(0, 10)}${this.additionalProperties}`;
+        const tagsString = this.tags.length > 0 ? ` ${this.tags.map(tag => `#${tag}`).join(" ")}` : "";
+
+        return `${prefix} ${this.description} (${label} ${rangeString})${tagsString} ⏳ ${this.scheduledDate.toISOString().slice(0, 10)}${this.additionalProperties}`;
     }
 }

--- a/src/pacerPlanStringParsing.ts
+++ b/src/pacerPlanStringParsing.ts
@@ -51,7 +51,7 @@ export function createPacerPlanFromString(
 
     metadataLines.forEach(applyMetadataLineToPacerPlan.bind(null, plan));
 
-    plan.tasks = taskStrings.map(t => createTaskFromTaskString(t, plan.quantityType));
+    plan.tasks = taskStrings.map(t => createTaskFromTaskString(t, plan.quantityType, plan.tags));
 
     return plan;
 }
@@ -62,7 +62,7 @@ export function createPacerPlanFromString(
  * @param taskString - The task string to parse.
  * @returns A Task object created from the task string.
  */
-export function createTaskFromTaskString(taskString: string, quantityType: string): Task {
+export function createTaskFromTaskString(taskString: string, quantityType: string, tags: string[]): Task {
 
     // regex to match the task string
     // - [x] Getting Things Done (pages 1-118) ⏳ 2024-08-19
@@ -71,7 +71,7 @@ export function createTaskFromTaskString(taskString: string, quantityType: strin
     // startPoint: 1
     // endPoint: 118
     // scheduledDate: 2024-08-19
-    const taskRegex = /^- (?<status>\[.\]) (?<description>.+) \(.*?(?<startPointString>\d+)(-(?<endPointString>\d+))?\) ⏳ (?<scheduledDateString>\d{4}-\d{2}-\d{2})(?<additionalProperties>.*)/;
+    const taskRegex = /^- (?<status>\[.\]) (?<description>.+) \(.*?(?<startPointString>\d+)(-(?<endPointString>\d+))?\)(?<tagsString>.+)? ⏳ (?<scheduledDateString>\d{4}-\d{2}-\d{2})(?<additionalProperties>.*)/;
 
     const match = taskString.match(taskRegex);
 
@@ -108,6 +108,7 @@ export function createTaskFromTaskString(taskString: string, quantityType: strin
         quantities,
         completed,
         scheduledDate,
+        tags,
         additionalProperties
     });
 }

--- a/src/pacerPlanStringParsing.ts
+++ b/src/pacerPlanStringParsing.ts
@@ -49,6 +49,8 @@ export function createPacerPlanFromString(
     const taskStrings = lines.slice(lines.indexOf("---", 1) + 1)
         .filter(line => line.trim().length > 0);
 
+    plan.tags = getTagsFromPlanString(planString);
+
     metadataLines.forEach(applyMetadataLineToPacerPlan.bind(null, plan));
 
     plan.tasks = taskStrings.map(t => createTaskFromTaskString(t, plan.quantityType, plan.tags));
@@ -146,4 +148,35 @@ export function applyMetadataLineToPacerPlan(plan: PacerPlan, line: string): voi
             plan.endNumber = parseInt(value);
             break;
     }
+}
+
+function getTagsFromPlanString(planString: string): string[] {
+    // tags
+    //   - work
+    //   - book
+
+    const tagsRegex = /^tags:$/;
+    const tagRegex = /^\s+-\s+(?<tag>.+)$/;
+    const lines = planString.split("\n");
+
+    let tags: string[] = [];
+
+    let tagsFound = false;
+    for (let line of lines) {
+        if (tagsFound) {
+            const match = line.match(tagRegex);
+            if (match) {
+                tags.push(match.groups!.tag);
+            } else {
+                break;
+            }
+        } else {
+            const match = line.match(tagsRegex);
+            if (match) {
+                tagsFound = true;
+            }
+        }
+    }
+
+    return tags;
 }

--- a/test/PacerPlan.helper.generateTasksForPacerPlan.startingFresh.test.ts
+++ b/test/PacerPlan.helper.generateTasksForPacerPlan.startingFresh.test.ts
@@ -317,5 +317,65 @@ describe("PacerPlan", () => {
                 })
             ]);
         });
+
+        it("when plan has tags: should correctly add tags to tasks", () => {
+            // Arrange
+            const plan = new PacerPlan({
+                title: "Book",
+                summary: "Read Book by Some Author",
+                quantityType: "Pages",
+                startDate: new Date(2024, 7, 19),
+                endDate: new Date(2024, 7, 21),
+                actionDays: Days.Everyday,
+                startNumber: 10,
+                endNumber: 10,
+                tags: ["work", "book"],
+                tasks: [
+                    new Task({
+                        description: "Book",
+                        quantityType: "Pages",
+                        quantities: [1, 2, 3, 4, 5, 6],
+                        scheduledDate: new Date(2024, 7, 19),
+                        completed: true
+                    }),
+                    new Task({
+                        description: "Book",
+                        quantityType: "Pages",
+                        quantities: [4, 5, 6, 7],
+                        scheduledDate: new Date(2024, 7, 20),
+                        completed: false
+                    }),
+                    new Task({
+                        description: "Book",
+                        quantityType: "Pages",
+                        quantities: [8, 9, 10],
+                        scheduledDate: new Date(2024, 7, 21),
+                        completed: false
+                    })
+                ]
+            });
+
+            // Act
+            const result = generateTasksForPacerPlan(plan, { today: () => new Date(2024, 7, 19) });
+
+            // Assert
+            expect(result).toEqual([
+                new Task({
+                    description: "Book",
+                    quantityType: "Pages",
+                    quantities: [1, 2, 3, 4, 5, 6],
+                    scheduledDate: new Date(2024, 7, 19),
+                    completed: true
+                }),
+                new Task({
+                    description: "Book",
+                    quantityType: "Pages",
+                    quantities: [10],
+                    scheduledDate: new Date(2024, 7, 20),
+                    completed: false,
+                    tags: ["work", "book"]
+                })
+            ]);
+        });
     });
 });

--- a/test/PacerPlan.toString.test.ts
+++ b/test/PacerPlan.toString.test.ts
@@ -22,21 +22,24 @@ describe("PacerPlan", () => {
                         quantityType: "Pages",
                         quantities: [5, 6, 7, 8, 9],
                         scheduledDate: new Date(2024, 7, 19),
-                        completed: true
+                        completed: true,
+                        tags: ["work", "book"],
                     }),
                     new Task({
                         description: "Book",
                         quantityType: "Pages",
                         quantities: [10, 11, 12, 13, 14],
                         scheduledDate: new Date(2024, 7, 20),
-                        completed: false
+                        completed: false,
+                        tags: ["work", "book"]
                     }),
                     new Task({
                         description: "Book",
                         quantityType: "Pages",
                         quantities: [15, 16, 17, 18, 19],
                         scheduledDate: new Date(2024, 7, 22),
-                        completed: false
+                        completed: false,
+                        tags: ["work", "book"]
                     })
                 ]
             });
@@ -57,9 +60,9 @@ tags:
   - work
   - book
 ---
-- [x] Book (pages 5-9) ⏳ 2024-08-19
-- [ ] Book (pages 10-14) ⏳ 2024-08-20
-- [ ] Book (pages 15-19) ⏳ 2024-08-22
+- [x] Book (pages 5-9) #work #book ⏳ 2024-08-19
+- [ ] Book (pages 10-14) #work #book ⏳ 2024-08-20
+- [ ] Book (pages 15-19) #work #book ⏳ 2024-08-22
 `);
         });
     });

--- a/test/PacerPlan.toString.test.ts
+++ b/test/PacerPlan.toString.test.ts
@@ -15,6 +15,7 @@ describe("PacerPlan", () => {
                 actionDays: Days.Monday | Days.Tuesday | Days.Thursday,
                 startNumber: 5,
                 endNumber: 19,
+                tags: ["work", "book"],
                 tasks: [
                     new Task({
                         description: "Book",
@@ -52,6 +53,9 @@ actionDays: MTR
 quantityType: Pages
 startNumber: 5
 endNumber: 19
+tags:
+  - work
+  - book
 ---
 - [x] Book (pages 5-9) ⏳ 2024-08-19
 - [ ] Book (pages 10-14) ⏳ 2024-08-20

--- a/test/Task.test.ts
+++ b/test/Task.test.ts
@@ -68,4 +68,21 @@ describe("toString", () => {
             });
         });
     });
+
+    describe("when there are tags", () => {
+        it("returns the correct string representation", () => {
+            const task = new Task({
+                description: "Sample Task",
+                quantityType: "Pages",
+                quantities: [55, 56, 57, 58, 59, 60],
+                scheduledDate: new Date("2022-02-01"),
+                completed: false,
+                tags: ["work", "book"]
+            });
+
+            const result = task.toString();
+
+            expect(result).toEqual("- [ ] Sample Task (pages 55-60) #work #book ⏳ 2022-02-01");
+        });
+    });
 });

--- a/test/pacerPlanStringParsing.createPacerPlanFromString.test.ts
+++ b/test/pacerPlanStringParsing.createPacerPlanFromString.test.ts
@@ -20,7 +20,6 @@ endNumber: 19
 - [ ] Book (pages 15-19) ⏳ 2024-08-22
 `;
 
-
         // Act
         const result = createPacerPlanFromString(planTitle, planContent);
 
@@ -121,5 +120,24 @@ endNumber: 4
         }
         );
         expect(result).toEqual(expectedPlan);
+    });
+
+    it("when plan has tags: should create a PacerPlan object from a string representation", () => {
+        const planTitle = "Book";
+        const planContent = `---
+summary: Read Book by Author
+startDate: 2024-08-19
+endDate: 2024-08-23
+actionDays: MTR
+quantityType: Pages
+startNumber: 1
+endNumber: 4
+tags:
+  - work
+  - book
+---
+- [x] Book (pages 1-2) #work #book ⏳ 2024-08-19
+- [ ] Book (page 3) #work #book ⏳ 2024-08-20
+`;
     });
 });

--- a/test/pacerPlanStringParsing.createTaskFromTaskString.test.ts
+++ b/test/pacerPlanStringParsing.createTaskFromTaskString.test.ts
@@ -2,17 +2,34 @@ import { createTaskFromTaskString } from "../src/pacerPlanStringParsing";
 import { Task } from "../src/Task";
 
 describe("createTaskFromTaskString", () => {
-    it("should create a Task object from a task string", () => {
+    it("should create a Task object from a task string when no tags", () => {
         const taskString = "- [x] Getting Things Done (pages 1-11) ⏳ 2024-08-19";
         const expectedTask = new Task({
             description: "Getting Things Done",
             quantityType: "Pages",
             quantities: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
             completed: true,
-            scheduledDate: new Date(2024, 7, 19)
+            scheduledDate: new Date(2024, 7, 19),
+            tags: []
         });
 
-        const result = createTaskFromTaskString(taskString, "Pages");
+        const result = createTaskFromTaskString(taskString, "Pages", []);
+
+        expect(result).toEqual(expectedTask);
+    });
+
+    it("should create a Task object from a task string when tags", () => {
+        const taskString = "- [x] Getting Things Done (pages 1-11) #work #book ⏳ 2024-08-19";
+        const expectedTask = new Task({
+            description: "Getting Things Done",
+            quantityType: "Pages",
+            quantities: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            completed: true,
+            scheduledDate: new Date(2024, 7, 19),
+            tags: ["work", "book"]
+        });
+
+        const result = createTaskFromTaskString(taskString, "Pages", ["work", "book"]);
 
         expect(result).toEqual(expectedTask);
     });


### PR DESCRIPTION
"I want the ability to add tags to my pacer plans so that its generated tasks include the tags as well. That way I can sort my tasks by context such as "work", "home", etc."

Closes #28